### PR TITLE
Move SplitSentences/Formatting Options to seperate Enum

### DIFF
--- a/src/Enum/TextHandlingEnum.php
+++ b/src/Enum/TextHandlingEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\DeeplApiConnector\Enum;
+
+final class TextHandlingEnum
+{
+    public const SPLITSENTENCES_ON = '1';
+    public const SPLITSENTENCES_OFF = '0';
+    public const SPLITSENTENCES_NONEWLINES = 'nonewlines';
+
+    public const PRESERVEFORMATTING_ON = '1';
+    public const PRESERVEFORMATTING_OFF = '0';
+}

--- a/src/Model/TranslationConfig.php
+++ b/src/Model/TranslationConfig.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Scn\DeeplApiConnector\Model;
 
+use Scn\DeeplApiConnector\Enum\TextHandlingEnum;
+
 final class TranslationConfig implements TranslationConfigInterface
 {
     private $text;
@@ -29,8 +31,8 @@ final class TranslationConfig implements TranslationConfigInterface
         array $tagHandling = [],
         array $nonSplittingTags = [],
         array $ignoreTags = [],
-        int $splitSentences = 1,
-        int $preserveFormatting = 0
+        string $splitSentences = TextHandlingEnum::SPLITSENTENCES_ON,
+        string $preserveFormatting = TextHandlingEnum::PRESERVEFORMATTING_OFF
     ) {
         $this->setText($text);
         $this->setTargetLang($targetLang);
@@ -114,24 +116,24 @@ final class TranslationConfig implements TranslationConfigInterface
         return $this;
     }
 
-    public function getSplitSentences(): int
+    public function getSplitSentences(): string
     {
         return $this->splitSentences;
     }
 
-    public function setSplitSentences(int $splitSentences): TranslationConfigInterface
+    public function setSplitSentences(string $splitSentences): TranslationConfigInterface
     {
         $this->splitSentences = $splitSentences;
 
         return $this;
     }
 
-    public function getPreserveFormatting(): int
+    public function getPreserveFormatting(): string
     {
         return $this->preserveFormatting;
     }
 
-    public function setPreserveFormatting(int $preserveFormatting): TranslationConfigInterface
+    public function setPreserveFormatting(string $preserveFormatting): TranslationConfigInterface
     {
         $this->preserveFormatting = $preserveFormatting;
 

--- a/src/Model/TranslationConfigInterface.php
+++ b/src/Model/TranslationConfigInterface.php
@@ -28,11 +28,11 @@ interface TranslationConfigInterface
 
     public function setIgnoreTags(array $ignoreTags): TranslationConfigInterface;
 
-    public function getSplitSentences(): int;
+    public function getSplitSentences(): string;
 
-    public function setSplitSentences(int $splitSentences): TranslationConfigInterface;
+    public function setSplitSentences(string $splitSentences): TranslationConfigInterface;
 
-    public function getPreserveFormatting(): int;
+    public function getPreserveFormatting(): string;
 
-    public function setPreserveFormatting(int $preserveFormatting): TranslationConfigInterface;
+    public function setPreserveFormatting(string $preserveFormatting): TranslationConfigInterface;
 }

--- a/tests/Handler/TranslationRequestHandlerTest.php
+++ b/tests/Handler/TranslationRequestHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Scn\DeeplApiConnector\Handler;
 
+use Scn\DeeplApiConnector\Enum\TextHandlingEnum;
 use Scn\DeeplApiConnector\Model\TranslationConfigInterface;
 use Scn\DeeplApiConnector\TestCase;
 
@@ -82,11 +83,11 @@ class TranslationRequestHandlerTest extends TestCase
 
         $this->translation->expects($this->once())
             ->method('getSplitSentences')
-            ->willReturn(1);
+            ->willReturn(TextHandlingEnum::SPLITSENTENCES_ON);
 
         $this->translation->expects($this->once())
             ->method('getPreserveFormatting')
-            ->willReturn(0);
+            ->willReturn(TextHandlingEnum::PRESERVEFORMATTING_ON);
 
         $this->assertSame(
             [
@@ -98,6 +99,7 @@ class TranslationRequestHandlerTest extends TestCase
                     'non_splitting_tags' => 'b,a,c',
                     'ignore_tags' => 'ef,fa,qa',
                     'split_sentences' => '1',
+                    'preserve_formatting' => '1',
                     'auth_key' => 'some key',
                 ],
             ],

--- a/tests/Model/TranslationConfigTest.php
+++ b/tests/Model/TranslationConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace Scn\DeeplApiConnector\Model;
 
+use Scn\DeeplApiConnector\Enum\TextHandlingEnum;
 use Scn\DeeplApiConnector\TestCase;
 
 class TranslationConfigTest extends TestCase
@@ -37,8 +38,8 @@ class TranslationConfigTest extends TestCase
 
     public function testGetPreserveFormattingCanReturnInteger()
     {
-        $this->subject->setPreserveFormatting(1);
-        $this->assertSame(1, $this->subject->getPreserveFormatting());
+        $this->subject->setPreserveFormatting(TextHandlingEnum::PRESERVEFORMATTING_ON);
+        $this->assertSame('1', $this->subject->getPreserveFormatting());
     }
 
     public function testGetTargetLangCanReturnString()
@@ -68,7 +69,7 @@ class TranslationConfigTest extends TestCase
 
     public function testGetSplitSentencesCanReturnInteger()
     {
-        $this->subject->setSplitSentences(1);
-        $this->assertSame(1, $this->subject->getSplitSentences());
+        $this->subject->setSplitSentences(TextHandlingEnum::SPLITSENTENCES_NONEWLINES);
+        $this->assertSame(TextHandlingEnum::SPLITSENTENCES_NONEWLINES, $this->subject->getSplitSentences());
     }
 }


### PR DESCRIPTION
- fixes #20
- also fixes type error of preserve formatting