### PR TITLE
Added native exception to `RequestException` as previous exception

### DIFF
--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -141,7 +141,8 @@ class DeeplClient implements DeeplClientInterface
             throw new RequestException(
                 $exception->getCode().
                 ' '.
-                $exception->getResponse()->getBody()->getContents()
+                $exception->getResponse()->getBody()->getContents(),
+                $exception
             );
         }
     }

--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -142,6 +142,7 @@ class DeeplClient implements DeeplClientInterface
                 $exception->getCode().
                 ' '.
                 $exception->getResponse()->getBody()->getContents(),
+                $exception->getCode(),
                 $exception
             );
         }


### PR DESCRIPTION
Hello,

while diagnosing DeepL connection issues, I added a simple tweak to include the native Guzzle request exception as previous exception in the thrown `RequestException` instance. This enables retrieving more diagnostic information on both the request and the response in scripts that catch it.

Cheers,

Sebastian Mordziol.