### PR TITLE
Add phpstan with level 9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,8 +37,5 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Run Codestyle Check
-        run: composer run-script check-cs
-
-      - name: Run test suite
-        run: composer run-script tests
+      - name: Run QA checks
+        run: composer run-script qa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.0] - TBD
+### Added
+- phpstan static analyses (dev)
+
 ## [3.0.0] - 2022-01-20
 ### Added
 - Support Deepl Free Api (https://support.deepl.com/hc/en/articles/360021200939-DeepL-API-Free)

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
         {
             "name": "Sascha Nützel",
             "homepage": "https://www.sc-networks.com"
+        },
+        {
+            "name": "Daniel Jakob",
+            "homepage": "https://www.sc-networks.com"
         }
     ],
     "require": {
@@ -25,6 +29,9 @@
         "friendsofphp/php-cs-fixer": "^3.5",
         "guzzlehttp/guzzle": "^7.0",
         "nyholm/psr7": "^1.4",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-mockery": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.1",
         "phpunit/phpunit": "^9"
     },
     "autoload": {
@@ -38,7 +45,9 @@
         }
     },
     "scripts": {
+        "qa": "composer check-cs && composer stan && composer tests",
         "tests": "vendor/bin/phpunit -c phpunit.xml.dist",
+        "stan": "vendor/bin/phpstan",
         "check-cs": "vendor/bin/php-cs-fixer fix --dry-run --diff",
         "fix-cs": "vendor/bin/php-cs-fixer fix"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,107 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Client\\\\ClientExceptionInterface\\:\\:getResponse\\(\\)\\.$#"
+			count: 1
+			path: src/DeeplClient.php
+
+		-
+			message: "#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Model/AbstractResponseModel.php
+
+		-
+			message: "#^Variable method call on \\$this\\(Scn\\\\DeeplApiConnector\\\\Model\\\\AbstractResponseModel\\)\\.$#"
+			count: 1
+			path: src/Model/AbstractResponseModel.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:__construct\\(\\) has parameter \\$ignoreTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:__construct\\(\\) has parameter \\$nonSplittingTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:__construct\\(\\) has parameter \\$tagHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:getIgnoreTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:getNonSplittingTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:getTagHandling\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:setIgnoreTags\\(\\) has parameter \\$ignoreTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:setNonSplittingTags\\(\\) has parameter \\$nonSplittingTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:setTagHandling\\(\\) has parameter \\$tagHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Property Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:\\$ignoreTags type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Property Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:\\$nonSplittingTags type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Property Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfig\\:\\:\\$tagHandling type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfig.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:getIgnoreTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:getNonSplittingTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:getTagHandling\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:setIgnoreTags\\(\\) has parameter \\$ignoreTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:setNonSplittingTags\\(\\) has parameter \\$nonSplittingTags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+
+		-
+			message: "#^Method Scn\\\\DeeplApiConnector\\\\Model\\\\TranslationConfigInterface\\:\\:setTagHandling\\(\\) has parameter \\$tagHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Model/TranslationConfigInterface.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+	level: 9
+	paths:
+		- src
+
+includes:
+	- phpstan-baseline.neon
+	- vendor/phpstan/phpstan-mockery/extension.neon
+	- vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -24,11 +24,11 @@ use stdClass;
 
 class DeeplClient implements DeeplClientInterface
 {
-    private $deeplRequestFactory;
+    private DeeplRequestFactoryInterface $deeplRequestFactory;
 
-    private $httpClient;
+    private ClientInterface $httpClient;
 
-    private $requestFactory;
+    private RequestFactoryInterface $requestFactory;
 
     public function __construct(
         DeeplRequestFactoryInterface $deeplRequestFactory,
@@ -126,13 +126,13 @@ class DeeplClient implements DeeplClientInterface
 
             $response = $this->httpClient->sendRequest($request);
 
-            if (in_array('application/json', $response->getHeader('Content-Type'))) {
-                return json_decode($response->getBody()->getContents());
+            if (in_array('application/json', $response->getHeader('Content-Type'), true)) {
+                $result = json_decode($response->getBody()->getContents());
             } else {
                 $content = new stdClass();
                 $content->content = $response->getBody()->getContents();
 
-                return $content;
+                $result = $content;
             }
         } catch (ClientExceptionInterface $exception) {
             throw new RequestException(
@@ -143,5 +143,8 @@ class DeeplClient implements DeeplClientInterface
                 $exception
             );
         }
+
+        /** @var stdClass $result */
+        return $result;
     }
 }

--- a/src/DeeplClientFactory.php
+++ b/src/DeeplClientFactory.php
@@ -25,10 +25,10 @@ final class DeeplClientFactory
         return new DeeplClient(
             new DeeplRequestFactory(
                 $authKey,
-                $streamFactory ?: Psr17FactoryDiscovery::findStreamFactory()
+                $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory()
             ),
-            $httpClient ?: Psr18ClientDiscovery::find(),
-            $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory()
+            $httpClient ?? Psr18ClientDiscovery::find(),
+            $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory()
         );
     }
 }

--- a/src/Handler/DeeplFileRequestHandler.php
+++ b/src/Handler/DeeplFileRequestHandler.php
@@ -10,11 +10,11 @@ final class DeeplFileRequestHandler implements DeeplRequestHandlerInterface
 {
     public const API_ENDPOINT = '/v2/document/%s/result';
 
-    private $authKey;
+    private string $authKey;
 
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    private $fileSubmission;
+    private FileSubmissionInterface $fileSubmission;
 
     public function __construct(
         string $authKey,

--- a/src/Handler/DeeplFileSubmissionRequestHandler.php
+++ b/src/Handler/DeeplFileSubmissionRequestHandler.php
@@ -12,11 +12,11 @@ final class DeeplFileSubmissionRequestHandler implements DeeplRequestHandlerInte
 {
     public const API_ENDPOINT = '/v2/document';
 
-    private $authKey;
+    private string $authKey;
 
-    private $fileTranslation;
+    private FileTranslationConfigInterface $fileTranslation;
 
-    private $multipartStreamBuilder;
+    private MultipartStreamBuilder $multipartStreamBuilder;
 
     public function __construct(
         string $authKey,

--- a/src/Handler/DeeplFileTranslationStatusRequestHandler.php
+++ b/src/Handler/DeeplFileTranslationStatusRequestHandler.php
@@ -12,11 +12,11 @@ final class DeeplFileTranslationStatusRequestHandler implements DeeplRequestHand
 {
     public const API_ENDPOINT = '/v2/document/%s';
 
-    private $authKey;
+    private string $authKey;
 
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    private $fileSubmission;
+    private FileSubmissionInterface $fileSubmission;
 
     public function __construct(
         string $authKey,

--- a/src/Handler/DeeplRequestFactory.php
+++ b/src/Handler/DeeplRequestFactory.php
@@ -15,9 +15,9 @@ final class DeeplRequestFactory implements DeeplRequestFactoryInterface
     public const DEEPL_PAID_BASE_URI = 'https://api.deepl.com';
     public const DEEPL_FREE_BASE_URI = 'https://api-free.deepl.com';
 
-    private $authKey;
+    private string $authKey;
 
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
     public function __construct(
         string $authKey,
@@ -79,7 +79,7 @@ final class DeeplRequestFactory implements DeeplRequestFactoryInterface
 
     public function getDeeplBaseUri(): string
     {
-        if (strpos($this->authKey, ':fx')) {
+        if (strpos($this->authKey, ':fx') !== false) {
             return DeeplRequestFactory::DEEPL_FREE_BASE_URI;
         }
 

--- a/src/Handler/DeeplTranslationRequestHandler.php
+++ b/src/Handler/DeeplTranslationRequestHandler.php
@@ -13,11 +13,11 @@ final class DeeplTranslationRequestHandler implements DeeplRequestHandlerInterfa
     private const SEPARATOR = ',';
     public const API_ENDPOINT = '/v2/translate';
 
-    private $authKey;
+    private string $authKey;
 
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    private $translation;
+    private TranslationConfigInterface $translation;
 
     public function __construct(
         string $authKey,
@@ -50,14 +50,14 @@ final class DeeplTranslationRequestHandler implements DeeplRequestHandlerInterfa
                         'source_lang' => $this->translation->getSourceLang(),
                         'tag_handling' => implode(
                             static::SEPARATOR,
-                            (array) $this->translation->getTagHandling()
+                            $this->translation->getTagHandling()
                         ),
                         'non_splitting_tags' => implode(
                             static::SEPARATOR,
-                            (array) $this->translation->getNonSplittingTags()
+                            $this->translation->getNonSplittingTags()
                         ),
-                        'ignore_tags' => implode(static::SEPARATOR, (array) $this->translation->getIgnoreTags()),
-                        'split_sentences' => (string) $this->translation->getSplitSentences(),
+                        'ignore_tags' => implode(static::SEPARATOR, $this->translation->getIgnoreTags()),
+                        'split_sentences' => $this->translation->getSplitSentences(),
                         'preserve_formatting' => $this->translation->getPreserveFormatting(),
                         'auth_key' => $this->authKey,
                     ]

--- a/src/Handler/DeeplUsageRequestHandler.php
+++ b/src/Handler/DeeplUsageRequestHandler.php
@@ -11,9 +11,9 @@ final class DeeplUsageRequestHandler implements DeeplRequestHandlerInterface
 {
     public const API_ENDPOINT = '/v2/usage';
 
-    private $authKey;
+    private string $authKey;
 
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
     public function __construct(
         string $authKey,

--- a/src/Model/FileSubmission.php
+++ b/src/Model/FileSubmission.php
@@ -6,9 +6,9 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class FileSubmission extends AbstractResponseModel implements FileSubmissionInterface
 {
-    private $documentId;
+    private string $documentId;
 
-    private $documentKey;
+    private string $documentKey;
 
     public function getDocumentId(): string
     {

--- a/src/Model/FileTranslation.php
+++ b/src/Model/FileTranslation.php
@@ -6,7 +6,7 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class FileTranslation extends AbstractResponseModel implements FileTranslationInterface
 {
-    private $content;
+    private string $content;
 
     public function getContent(): string
     {

--- a/src/Model/FileTranslationConfig.php
+++ b/src/Model/FileTranslationConfig.php
@@ -6,13 +6,13 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class FileTranslationConfig implements FileTranslationConfigInterface
 {
-    private $fileContent;
+    private string $fileContent;
 
-    private $fileName;
+    private string $fileName;
 
-    private $targetLang;
+    private string $targetLang;
 
-    private $sourceLang;
+    private string $sourceLang;
 
     public function __construct(
         string $fileContent,

--- a/src/Model/FileTranslationStatus.php
+++ b/src/Model/FileTranslationStatus.php
@@ -6,13 +6,13 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class FileTranslationStatus extends AbstractResponseModel implements FileTranslationStatusInterface
 {
-    private $documentId;
+    private string $documentId;
 
-    private $status;
+    private string $status;
 
-    private $secondsRemaining;
+    private ?int $secondsRemaining;
 
-    private $billedCharacters;
+    private int $billedCharacters;
 
     public function getDocumentId(): string
     {

--- a/src/Model/Translation.php
+++ b/src/Model/Translation.php
@@ -6,9 +6,9 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class Translation extends AbstractResponseModel implements TranslationInterface
 {
-    private $detectedSourceLanguage;
+    private string $detectedSourceLanguage;
 
-    private $text;
+    private string $text;
 
     public function getDetectedSourceLanguage(): string
     {

--- a/src/Model/TranslationConfig.php
+++ b/src/Model/TranslationConfig.php
@@ -8,21 +8,21 @@ use Scn\DeeplApiConnector\Enum\TextHandlingEnum;
 
 final class TranslationConfig implements TranslationConfigInterface
 {
-    private $text;
+    private string $text;
 
-    private $targetLang;
+    private string $targetLang;
 
-    private $sourceLang;
+    private string $sourceLang;
 
-    private $tagHandling;
+    private array $tagHandling;
 
-    private $nonSplittingTags;
+    private array $nonSplittingTags;
 
-    private $ignoreTags;
+    private array $ignoreTags;
 
-    private $splitSentences;
+    private string $splitSentences;
 
-    private $preserveFormatting;
+    private string $preserveFormatting;
 
     public function __construct(
         string $text,

--- a/src/Model/Usage.php
+++ b/src/Model/Usage.php
@@ -6,9 +6,9 @@ namespace Scn\DeeplApiConnector\Model;
 
 final class Usage extends AbstractResponseModel implements UsageInterface
 {
-    private $characterCount;
+    private int $characterCount;
 
-    private $characterLimit;
+    private int $characterLimit;
 
     public function getCharacterCount(): int
     {


### PR DESCRIPTION
- Add new composer script entries for stan and qa (executes all
  qa-related scripts)
- Correct some typing issues

This also adds types for the internal Model properties. As strict typing
is enabled and the setter/getters are already types, adding types
without defaults should be safe.