### PR TITLE
Added a method to fetch the response body.

### DIFF
--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -164,13 +164,13 @@ class DeeplClient implements DeeplClientInterface
      */
     private function resolveResponseBody(ClientExceptionInterface $exception) : string
     {
-        if(!method_exists($exception, 'getResponse')) {
+        if (!method_exists($exception, 'getResponse')) {
             return '(response body not provided)';
         }
 
         $response = $exception->getResponse();
 
-        if($response instanceof ResponseInterface) {
+        if ($response instanceof ResponseInterface) {
             return $response->getBody()->getContents();
         }
 

--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -164,15 +164,13 @@ class DeeplClient implements DeeplClientInterface
      */
     private function resolveResponseBody(ClientExceptionInterface $exception) : string
     {
-        if(!method_exists($exception, 'getResponse'))
-        {
+        if(!method_exists($exception, 'getResponse')) {
             return '(response body not provided)';
         }
 
         $response = $exception->getResponse();
 
-        if($response instanceof ResponseInterface)
-        {
+        if($response instanceof ResponseInterface) {
             return $response->getBody()->getContents();
         }
 


### PR DESCRIPTION
I added this method to check whether the client exception has the `getResponse()` method. The PSR interfaces do not include this method, and it is not available for all client exceptions. 

I ran into this issue when using Guzzle with a proxy, and the proxy was not reachable - the client exception did not have any response information, which caused a PHP error trying to call `getResponse()` when creating the exception in `executeRequest()`.

I was unsure how to add a unit test for this, so I did not include one.