### PR TITLE
Remove `getResponse()` from the request exception

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,9 +1,5 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Call to an undefined method Psr\\\\Http\\\\Client\\\\ClientExceptionInterface\\:\\:getResponse\\(\\)\\.$#"
-			count: 1
-			path: src/DeeplClient.php
 
 		-
 			message: "#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#"

--- a/src/DeeplClient.php
+++ b/src/DeeplClient.php
@@ -136,9 +136,7 @@ class DeeplClient implements DeeplClientInterface
             }
         } catch (ClientExceptionInterface $exception) {
             throw new RequestException(
-                $exception->getCode().
-                ' '.
-                $exception->getResponse()->getBody()->getContents(),
+                $exception->getMessage(),
                 $exception->getCode(),
                 $exception
             );

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -3,7 +3,17 @@
 namespace Scn\DeeplApiConnector\Exception;
 
 use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
 
+/**
+ * NOTE: Use `getPrevious()` to access the initial
+ * {@see ClientExceptionInterface} exception that was
+ * triggered.
+ *
+ * Depending on the HTTP implementation (e.g. GuzzleHttp),
+ * this can allow access to additional information
+ * (HTTP response details, for example).
+ */
 class RequestException extends Exception
 {
 }

--- a/tests/DeeplClientTest.php
+++ b/tests/DeeplClientTest.php
@@ -60,20 +60,7 @@ class DeeplClientTest extends TestCase
         $this->deeplRequestFactory->method('createDeeplUsageRequestHandler')
             ->willReturn($requestHandler);
 
-        $stream = $this->createMock(StreamInterface::class);
-        $stream->expects($this->once())
-            ->method('getContents')
-            ->willReturn('some content');
-
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())
-            ->method('getBody')
-            ->willReturn($stream);
-
         $clientException = $this->createMock(ClientException::class);
-        $clientException->expects($this->once())
-            ->method('getResponse')
-            ->willReturn($response);
 
         $request = $this->createRequestExpectations(
             $requestHandler,
@@ -144,20 +131,7 @@ class DeeplClientTest extends TestCase
         $this->deeplRequestFactory->method('createDeeplTranslationRequestHandler')
             ->willReturn($requestHandler);
 
-        $stream = $this->createMock(StreamInterface::class);
-        $stream->expects($this->once())
-            ->method('getContents')
-            ->willReturn('some content');
-
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())
-            ->method('getBody')
-            ->willReturn($stream);
-
         $clientException = $this->createMock(ClientException::class);
-        $clientException->expects($this->once())
-            ->method('getResponse')
-            ->willReturn($response);
 
         $request = $this->createRequestExpectations(
             $requestHandler,


### PR DESCRIPTION
As @usox mentioned ([see comment](https://github.com/SC-Networks/deepl-api-connector/pull/61#issuecomment-1109490944)), I have removed the `getResponse()` call entirely from the request exception. I have also added some hints to the `RequestException` on how to access additional data like the response details.