### PR TITLE
Fixed unset property PHP error.

### DIFF
--- a/src/Model/Translation.php
+++ b/src/Model/Translation.php
@@ -22,9 +22,14 @@ final class Translation extends AbstractResponseModel implements TranslationInte
         return $this;
     }
 
+    public function hasText() : bool
+    {
+        return isset($this->text);
+    }
+    
     public function getText(): string
     {
-        return $this->text;
+        return $this->text ?? '';
     }
 
     public function setText(string $text): TranslationInterface


### PR DESCRIPTION
I ran into an issue where the `Translation::$text` property could be uninitialised. This causes a PHP error when trying to call `getText()`. As there was no way to see if the text was set or not, there was no way to circumvent the issue.

As a solution, I made the `getText()` method always return a string, and added the `hasText()` method to check if it has been set.


FYI, this happened in my case because my API key was invalid, which caused DeepL to return a 403: Forbidden status. Because I have no error handler in my HTTP middleware, the 403 status code does not trigger an exception, causing the `Translation` instance to be created without a text set.