### PR TITLE
Throw RequestExeption on client- or server errors #68

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         php: ['7.4', '8.0', '8.1', '8.2']
-    continue-on-error: ${{ matrix.php == '8.2' }}
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Compatibility
 | Connector-Version               | PHP-Version(s)     |
 |---------------------------------|--------------------|
 | **master** (dev)                | TBD                |
-| **3.x** (features and bugfixes) | 7.4, 8.0, 8.1      |
-| **2.x** (bugfixes only)         | 7.3, 7.4, 8.0, 8.1 |
+| **3.x** (features and bugfixes) | 7.4, 8.0, 8.1, 8.2 |
+| **2.x** (EOL)                   | 7.3, 7.4, 8.0, 8.1 |
 | **1.x** (EOL)                   | 7.2, 7.3, 7.4      |
 
 ## Install


### PR DESCRIPTION
If the used http client does no (proper) error handling himself (e.g. catching server errors and such), look for status codes beginning with 4 or 5 and throw a RequestException.

Also:
- Mark 2.x as EOL
- Add PHP 8.2 in version matrix