### PR TITLE
Remove source_lang from file translation request if empty

### DIFF
--- a/src/Handler/DeeplFileSubmissionRequestHandler.php
+++ b/src/Handler/DeeplFileSubmissionRequestHandler.php
@@ -40,13 +40,19 @@ final class DeeplFileSubmissionRequestHandler implements DeeplRequestHandlerInte
 
     public function getBody(): StreamInterface
     {
-        return $this->multipartStreamBuilder
+        $streamBuilder = $this->multipartStreamBuilder
             ->setBoundary('boundary')
             ->addResource('auth_key', $this->authKey)
             ->addResource('file', $this->fileTranslation->getFileContent(), ['filename' => $this->fileTranslation->getFileName()])
-            ->addResource('source_lang', $this->fileTranslation->getSourceLang())
-            ->addResource('target_lang', $this->fileTranslation->getTargetLang())
-            ->build();
+            ->addResource('target_lang', $this->fileTranslation->getTargetLang());
+
+        // add sourceLanguage only if set, otherwise the file won't be translated #26
+        $sourceLanguage = $this->fileTranslation->getSourceLang();
+        if ($sourceLanguage !== '') {
+            $streamBuilder = $streamBuilder->addResource('source_lang', $sourceLanguage);
+        }
+
+        return $streamBuilder->build();
     }
 
     public function getContentType(): string

--- a/tests/Handler/DeeplFileSubmissionRequestHandlerTest.php
+++ b/tests/Handler/DeeplFileSubmissionRequestHandlerTest.php
@@ -65,13 +65,55 @@ class DeeplFileSubmissionRequestHandlerTest extends TestCase
         $this->streamBuilder->expects($this->once())
             ->method('setBoundary')
             ->with('boundary')
-            ->willReturn($this->streamBuilder);
+            ->willReturnSelf();
         $this->streamBuilder->expects($this->exactly(4))
             ->method('addResource')
             ->withConsecutive(
                 ['auth_key', 'some key'],
                 ['file', 'file content', ['filename' => 'file name']],
-                ['source_lang', 'source lang'],
+                ['target_lang', 'target lang'],
+                ['source_lang', 'source lang']
+            )
+            ->willReturnSelf();
+        $this->streamBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn($stream);
+
+        $this->assertSame(
+            $stream,
+            $this->subject->getBody()
+        );
+    }
+
+    public function testGetBodyIgnoresSourceLangIfEmpty(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+
+        $this->fileTranslation->expects($this->once())
+            ->method('getFileName')
+            ->willReturn('file name');
+
+        $this->fileTranslation->expects($this->once())
+            ->method('getFileContent')
+            ->willReturn('file content');
+
+        $this->fileTranslation->expects($this->once())
+            ->method('getSourceLang')
+            ->willReturn('');
+
+        $this->fileTranslation->expects($this->once())
+            ->method('getTargetLang')
+            ->willReturn('target lang');
+
+        $this->streamBuilder->expects($this->once())
+            ->method('setBoundary')
+            ->with('boundary')
+            ->willReturnSelf();
+        $this->streamBuilder->expects($this->exactly(3))
+            ->method('addResource')
+            ->withConsecutive(
+                ['auth_key', 'some key'],
+                ['file', 'file content', ['filename' => 'file name']],
                 ['target_lang', 'target lang']
             )
             ->willReturnSelf();


### PR DESCRIPTION
Empty source lang causes the file to be ignored.

Fixes #26