### PR TITLE
Update TranslationConfig.php

### DIFF
--- a/src/Model/TranslationConfig.php
+++ b/src/Model/TranslationConfig.php
@@ -43,7 +43,7 @@ final class TranslationConfig implements TranslationConfigInterface
         array $ignoreTags = [],
         string $splitSentences = TextHandlingEnum::SPLITSENTENCES_ON,
         string $preserveFormatting = TextHandlingEnum::PRESERVEFORMATTING_OFF,
-        string $glossaryId = '',
+        string $glossaryId = ''
     ) {
         $this->setText($text);
         $this->setTargetLang($targetLang);


### PR DESCRIPTION
I get this error without the commit removing the trailing comma:

ParseError: syntax error, unexpected ')', expecting variable (T_VARIABLE) in /var/customers/webs/xxx/yii2/xxx/vendor/scn/deepl-api-connector/src/Model/TranslationConfig.php:44